### PR TITLE
Add initial templates to run a Nodejs Lambda that reads dynamo data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Terraform/.terraform/
 Terraform/.terraform.lock.hcl
 Terraform/terraform.tfstate
 Terraform/terraform.tfstate.backup
+Terraform/cardalog_data_reader_function.zip

--- a/Node/cardalog_data_reader_function.js
+++ b/Node/cardalog_data_reader_function.js
@@ -1,0 +1,34 @@
+const AWS = require('aws-sdk');
+const docClient = new AWS.DynamoDB.DocumentClient();
+
+exports.handler = async (event) => {
+    try {
+        // Parameters to query DynamoDB table
+        const params = {
+            TableName: 'cardalog-card-data',
+            Key: {
+                primaryKeyCardalog: 'testorino'
+            }
+        };
+
+        // Query DynamoDB table
+        const data = await docClient.get(params).promise();
+
+        // Log the retrieved data
+        console.log('Retrieved data from DynamoDB:', data);
+
+        // Return the retrieved item
+        return {
+            statusCode: 200,
+            body: JSON.stringify(data.Item)
+        };
+    } catch (error) {
+        console.error('Error retrieving data from DynamoDB:', error);
+
+        // Return an error response
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ error: 'Internal Server Error' })
+        };
+    }
+};

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Initial Architecture Plan:
 
 - Image-data stored in S3
 - Text-data stored in DynamoDB
-- Lambda polls DynamoDB based on input parameters, and returns text and image data
-- Frontend stored in S3
+- Lambdas stored in separate S3
+- Lambda polls DynamoDB based on input parameters, and returns text data
+- Separate Lambda polls S3 based on input parameters, and returns matching image data
+- Frontend stored in separate S3
 - Frontend triggers Lambdas through API gateway
 
 Tools used:

--- a/Terraform/dynamo.tf
+++ b/Terraform/dynamo.tf
@@ -5,13 +5,14 @@ provider "aws" {
   alias = "dynamo"
 }
 
-resource "random_pet" "dynamo_suffix" {
-  length    = 2  # specify the length of the random string
-  separator = "-"
-}
+#resource "random_pet" "dynamo_suffix" {
+#  length    = 2  # specify the length of the random string
+#  separator = "-"
+#}
 
 resource "aws_dynamodb_table" "cardalog_card_data" {
-  name           = "cardalog-card-data-${random_pet.dynamo_suffix.id}"
+  #name           = "cardalog-card-data-${random_pet.dynamo_suffix.id}"
+  name           = "cardalog-card-data"
   billing_mode   = "PROVISIONED"  # or "PAY_PER_REQUEST" for on-demand billing
   read_capacity  = 5               # Adjust according to your read/write needs
   write_capacity = 5

--- a/Terraform/lambda.tf
+++ b/Terraform/lambda.tf
@@ -1,0 +1,115 @@
+provider "aws" {
+  region = "eu-north-1"
+  alias = "lambda"
+}
+
+resource "random_pet" "lambda_bucket_suffix" {
+  length    = 2  # specify the length of the random string
+  separator = "-"
+}
+
+resource "aws_s3_bucket" "cardalog_lambda_bucket" {
+  bucket = "cardalog-lambda-bucket-${random_pet.lambda_bucket_suffix.id}"
+}
+
+resource "aws_lambda_permission" "cardalog_s3_invoke_lambda" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cardalog_data_reader.arn
+  principal     = "s3.amazonaws.com"
+
+  # Specify the ARN of the S3 bucket that will trigger the Lambda function
+  #source_arn = aws_s3_bucket.example_bucket.arn
+
+  # Specify the S3 event types that will trigger the Lambda function
+  #source_account = "${var.aws_account_id}"  # Replace with your AWS account ID
+  # Events: s3:ObjectCreated:*, s3:ObjectRemoved:* etc.
+  # You can specify more detailed events based on your requirements
+  # For example, you can specify only s3:ObjectCreated events by using ["s3:ObjectCreated:*"]
+  # or a specific prefix/key with ["s3:ObjectCreated:*"] and filter_suffix
+  # (e.g., filter_suffix = ".jpg" to only trigger for .jpg files)
+  # Uncomment the following line and adjust the event types as needed:
+  # events = ["s3:ObjectCreated:*"]
+}
+
+data "archive_file" "cardalog_lambda_zip" {
+  type        = "zip"
+  output_path = "cardalog_data_reader_function.zip"
+  source_dir  = "../Node"  # Path to the directory containing your Lambda function code
+}
+
+resource "aws_s3_bucket_object" "cardalog_lambda_zip_object" {
+  bucket = aws_s3_bucket.cardalog_lambda_bucket.id
+  key    = "cardalog_data_reader_function.zip"
+  source = data.archive_file.cardalog_lambda_zip.output_path
+}
+
+#resource "random_pet" "lambda_suffix" {
+#  length    = 2  # specify the length of the random string
+#  separator = "-"
+#}
+
+resource "aws_lambda_function" "cardalog_data_reader" {
+  filename         = "cardalog_data_reader_function.zip"  # path to the ZIP file containing your Lambda code
+  #function_name    = "cardalog_data_reader-${random_pet.lambda_suffix.id}"  # name of your Lambda function
+  function_name    = "cardalog_data_reader"
+  role             = aws_iam_role.cardalog_lambda_role.arn  # ARN of the IAM role associated with your Lambda function
+  handler          = "lambda_function.handler"  # name of the handler function in your Lambda code
+  runtime          = "nodejs18.x"  # runtime environment for your Lambda function
+  
+  # Optional configuration
+  memory_size      = 128  # memory allocated to the Lambda function in MB
+  timeout          = 30   # maximum execution time for the Lambda function in seconds
+}
+
+# IAM role for Lambda function
+resource "aws_iam_role" "cardalog_lambda_role" {
+  name = "cardalog_lambda_execution_role"  # name of the IAM role
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+# IAM policy for Lambda function
+resource "aws_iam_policy" "cardalog_lambda_policy" {
+  name        = "cardalog_lambda_execution_policy"  # name of the IAM policy
+  description = "Policy for Lambda execution role"  # description of the IAM policy
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "logs:CreateLogGroup",
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}
+EOF
+}
+
+# Attach the policy to the IAM role
+resource "aws_iam_role_policy_attachment" "cardalog_lambda_policy_attachment" {
+  role       = aws_iam_role.cardalog_lambda_role.name
+  policy_arn = aws_iam_policy.cardalog_lambda_policy.arn
+}


### PR DESCRIPTION
Add Terraform Template file that contains:
- S3 Bucket for holding Lambdas
- Lambda for reading DynamoDB data
- assorted Policies to enable S3 storage and Lambda invocation

Add Node Directory for containing Nodejs Lambda functions

Add cardalog_data_reader_function Nodejs function