### PR TITLE
Configure Remote S3 backend for cross-machine state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ aws configure
 
 # Terraform
 
-## Initialize Terraform resources:
+NOTE:
+The ftState file is stored remotely in an S3 Bucket.
+This enables sharing state between multiple machines.
+HOWEVER
+This means that the name of the bucket in main.tf needs to added manually for
+the 'backend' section, as terraform does not allow variables here.
+
+## Initialize Terraform resources (first time):
 
 1. Open Command Line/Command Prompt
 2. Navigate to Terraform/ directory

--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -19,3 +19,26 @@ resource "aws_s3_bucket" "cardalog-picture-bucket" {
     Environment = "Development"
   }
 }
+
+resource "aws_s3_bucket" "cardalog-tfstate-bucket" {
+  bucket = "cardalog-tfstate-${random_pet.bucket_suffix.id}"  # specify a globally unique bucket name
+
+  acl    = "private"  # Access Control List for the bucket, you can change it as needed
+
+  tags = {
+    Name        = "TfstateBucket"
+    Environment = "Development"
+  }
+}
+
+terraform {
+  backend "s3" {
+    # NOTE that the bucket name below needs to be hard-coded
+    # Change name to match your personally generated name from cardalog-tfstate-${random_pet.bucket_suffix.id} above
+    bucket         = "cardalog-tfstate-lately-saved-krill"
+    key            = "terraform/state/terraform.tfstate"
+    region         = "eu-north-1"
+    #dynamodb_table = "your-dynamodb-table-name"
+    encrypt        = true
+  }
+}


### PR DESCRIPTION
Add new S3 bucket to main.tf
Add new backend section to main.tf
-> Together these will be used to store tfstate remotely, enabling multiple machines to utilize the same state without having to include the tfstate file in version control